### PR TITLE
Enable PL2 weighting scheme evaluation

### DIFF
--- a/src/config_file.cc
+++ b/src/config_file.cc
@@ -441,6 +441,13 @@ bool CONFIG_TREC::check_bm25plus() {
 	return true;
 }
 
+bool CONFIG_TREC::check_pl2() {
+//make sure that parameters required by PL2 are available.
+	if ( pl2param_c == -1.0 ) {
+		return false;
+	}
+	return true;
+}
 
 bool CONFIG_TREC::use_weightingscheme(string scheme) {
 

--- a/src/config_file.cc
+++ b/src/config_file.cc
@@ -219,6 +219,11 @@ void CONFIG_TREC::record_tag( string config_tag, string config_value ) {
   	found = 1;
   }
 
+  if (config_tag == "pl2param_c") {
+	pl2param_c = strtof(config_value.c_str(), NULL);
+	found = 1;
+  }
+
   if( !found ) {
     cout << "ERROR: could not locate tag [" << config_tag << "] for value [" << config_value
 	 << "]" << endl;

--- a/src/config_file.cc
+++ b/src/config_file.cc
@@ -264,7 +264,7 @@ void CONFIG_TREC::setup_config( string filename ) {
   bm25plusparam_b = -1.0;
   bm25plusparam_min_normlen = -1.0;
   bm25plusparam_delta = -1.0;
-  pl2param_c = 1.0;
+  pl2param_c = -1.0;
   tradparam_k = -1.0;
   lmparam_log = -1.0;
   lmparam_smoothing1 = -1.0;

--- a/src/config_file.cc
+++ b/src/config_file.cc
@@ -264,6 +264,7 @@ void CONFIG_TREC::setup_config( string filename ) {
   bm25plusparam_b = -1.0;
   bm25plusparam_min_normlen = -1.0;
   bm25plusparam_delta = -1.0;
+  pl2param_c = 1.0;
   tradparam_k = -1.0;
   lmparam_log = -1.0;
   lmparam_smoothing1 = -1.0;

--- a/src/config_file.h
+++ b/src/config_file.h
@@ -144,6 +144,8 @@ public:
 	double get_bm25plusparam_min_normlen() { return bm25plusparam_min_normlen; }
 	double get_bm25plusparam_delta() { return bm25plusparam_delta; }
 
+	double get_pl2param_c() { return pl2param_c; }
+
 	double get_tradparam_k() { return tradparam_k; }
 	
 	double get_lmparam_log() { return lmparam_log; }

--- a/src/config_file.h
+++ b/src/config_file.h
@@ -102,6 +102,7 @@ public:
 	bool check_trad();
 	bool check_lmweight();
 	bool check_bm25plus();
+	bool check_pl2();
 
 	// access routines
 	string get_textfile() { return textfile; }

--- a/src/config_file.h
+++ b/src/config_file.h
@@ -69,6 +69,9 @@ private:
 	double bm25plusparam_min_normlen;
 	double bm25plusparam_delta;
 
+	//Parameters for PL2 Weighting Scheme.
+	double pl2param_c;
+
 	//Parameters for Tras Weighting scheme.
 	double tradparam_k;
 

--- a/src/trec_search.cc
+++ b/src/trec_search.cc
@@ -176,6 +176,14 @@ int main(int argc, char **argv)
 		else {
 			enquire.set_weighting_scheme(Xapian::BM25PlusWeight());		   }
 	}
+	else if (config.use_weightingscheme("pl2"))
+	{
+		if (config.check_pl2()) {
+			enquire.set_weighting_scheme(Xapian::PL2Weight(config.get_pl2param_c()));
+		} else {
+			enquire.set_weighting_scheme(Xapian::PL2Weight());
+		}
+	}
 	// Get the top n results of the query
 	Xapian::MSet matches = enquire.get_mset( 0, config.get_noresults() );
 								


### PR DESCRIPTION
Added support for PL2 weighting scheme so we can evaluate and compare it with PL2+ weighting scheme; builds successfully. Please let me know if anything needs to be modified in this PR.
