### PR TITLE
Enable PL2+ weighting scheme evaluation

### DIFF
--- a/src/config_file.cc
+++ b/src/config_file.cc
@@ -219,6 +219,16 @@ void CONFIG_TREC::record_tag( string config_tag, string config_value ) {
   	found = 1;
   }
 
+  if (config_tag == "pl2plusparam_c" ) {
+	pl2plusparam_c = strtod(config_value.c_str(), NULL);
+	found = 1;
+  }
+
+  if (config_tag == "pl2plusparam_delta" ) {
+	pl2plusparam_delta = strtod(config_value.c_str(), NULL);
+	found = 1;
+  }
+
   if( !found ) {
     cout << "ERROR: could not locate tag [" << config_tag << "] for value [" << config_value
 	 << "]" << endl;
@@ -259,6 +269,8 @@ void CONFIG_TREC::setup_config( string filename ) {
   bm25plusparam_b = -1.0;
   bm25plusparam_min_normlen = -1.0;
   bm25plusparam_delta = -1.0;
+  pl2plusparam_c = -1.0;
+  pl2plusparam_delta = -1.0;
   tradparam_k = -1.0;
   lmparam_log = -1.0;
   lmparam_smoothing1 = -1.0;
@@ -435,6 +447,16 @@ bool CONFIG_TREC::check_bm25plus() {
 	return true;
 }
 
+bool CONFIG::check_pl2plus() {
+// make sure that all PL2+ parameters are available.
+	if ( pl2plusparam_c == -1.0 ) {
+		return false;
+	}
+	if ( pl2plusparam_delta == -1.0 ) {
+		return false;
+	}
+	return true;
+}
 
 bool CONFIG_TREC::use_weightingscheme(string scheme) {
 

--- a/src/config_file.h
+++ b/src/config_file.h
@@ -69,6 +69,10 @@ private:
 	double bm25plusparam_min_normlen;
 	double bm25plusparam_delta;
 
+	//Parameters for PL2+ Weighting Scheme.
+	double pl2plusparam_c;
+	double pl2plusparam_delta;
+
 	//Parameters for Tras Weighting scheme.
 	double tradparam_k;
 
@@ -99,6 +103,7 @@ public:
 	bool check_trad();
 	bool check_lmweight();
 	bool check_bm25plus();
+	bool check_pl2plus();
 
 	// access routines
 	string get_textfile() { return textfile; }
@@ -140,14 +145,16 @@ public:
 	double get_bm25plusparam_min_normlen() { return bm25plusparam_min_normlen; }
 	double get_bm25plusparam_delta() { return bm25plusparam_delta; }
 
+	double get_pl2plusparam_c() { return pl2plusparam_c; }
+	double get_pl2plusparam_delta() { return pl2plusparam_delta; }
+
 	double get_tradparam_k() { return tradparam_k; }
 	
 	double get_lmparam_log() { return lmparam_log; }
 
 	Xapian::Weight::type_smoothing get_lmparam_select_smoothing() { return lmparam_select_smoothing; }
 
-	double get_lmparam_smoothing1() { return lmparam_smoothing1
-; }
+	double get_lmparam_smoothing1() { return lmparam_smoothing1; }
 	
 	double get_lmparam_smoothing2() { return lmparam_smoothing2; }
 

--- a/src/trec_search.cc
+++ b/src/trec_search.cc
@@ -176,6 +176,13 @@ int main(int argc, char **argv)
 		else {
 			enquire.set_weighting_scheme(Xapian::BM25PlusWeight());		   }
 	}
+	else if (config.use_weightingscheme("pl2plus"))
+	{
+		if (config.check_pl2plus()) {
+			enquire.set_weighting_scheme(Xapian::PL2PlusWeight(config.get_pl2plusparam_c(), config.get_pl2plusparam_delta()));
+		} else {
+			enquire.set_weighting_scheme(Xapian::PL2PlusWeight());
+	}
 	// Get the top n results of the query
 	Xapian::MSet matches = enquire.get_mset( 0, config.get_noresults() );
 								


### PR DESCRIPTION
This PR requires PL2+ weighting scheme support implemented in Xapian to build successfully. Please refer [here](https://github.com/xapian/xapian/pull/108) to obtain PL2+ implementation and move xapian-evaluation folder to xapian source root directory. 
