### PR TITLE
Enable Dir+ weighting scheme evaluation

### DIFF
--- a/src/config_file.cc
+++ b/src/config_file.cc
@@ -188,7 +188,7 @@ void CONFIG_TREC::record_tag( string config_tag, string config_value ) {
 	found = 1;
 	}
 	if (config_value.compare("DIRICHLET_PLUS_SMOOTHING") == 0 ) {
-		lmparam_select_smoothing = Xapian::Weight::JELINEK_MERCER_SMOOTHING;
+		lmparam_select_smoothing = Xapian::Weight::DIRICHLET_PLUS_SMOOTHING;
 	found = 1;
 	}
   }

--- a/src/config_file.cc
+++ b/src/config_file.cc
@@ -187,16 +187,10 @@ void CONFIG_TREC::record_tag( string config_tag, string config_value ) {
 		lmparam_select_smoothing = Xapian::Weight::JELINEK_MERCER_SMOOTHING;
 	found = 1;
 	}
-  }
-
-  if (config_tag == "dirparam_delta" ) {
-	lmparam_delta = strtod(config_value.c_str(), NULL);
+	if (config_value.compare("DIRICHLET_PLUS_SMOOTHING") == 0 ) {
+		lmparam_select_smoothing = Xapian::Weight::JELINEK_MERCER_SMOOTHING;
 	found = 1;
-  }
-
-  if (config_tag == "enable_dirplus" ) {
-	lmparam_enable_dirplus = strtod(config_value.c_str(), NULL);
-	found = 1;
+	}
   }
 
   if (config_tag == "bm25plusparam_k1" ) {

--- a/src/config_file.cc
+++ b/src/config_file.cc
@@ -189,12 +189,12 @@ void CONFIG_TREC::record_tag( string config_tag, string config_value ) {
 	}
   }
 
-  if (config_tag == "lmparam_delta" ) {
+  if (config_tag == "dirparam_delta" ) {
 	lmparam_delta = strtod(config_value.c_str(), NULL);
 	found = 1;
   }
 
-  if (config_tag == "lmparam_enable_dirplus" ) {
+  if (config_tag == "enable_dirplus" ) {
 	lmparam_enable_dirplus = strtod(config_value.c_str(), NULL);
 	found = 1;
   }

--- a/src/config_file.cc
+++ b/src/config_file.cc
@@ -188,7 +188,17 @@ void CONFIG_TREC::record_tag( string config_tag, string config_value ) {
 	found = 1;
 	}
   }
-  
+
+  if (config_tag == "lmparam_delta" ) {
+	lmparam_delta = strtod(config_value.c_str(), NULL);
+	found = 1;
+  }
+
+  if (config_tag == "lmparam_enable_dirplus" ) {
+	lmparam_enable_dirplus = strtod(config_value.c_str(), NULL);
+	found = 1;
+  }
+
   if (config_tag == "bm25plusparam_k1" ) {
 	bm25plusparam_k1 = strtod(config_value.c_str(),NULL);
 	found = 1;

--- a/src/config_file.h
+++ b/src/config_file.h
@@ -79,8 +79,6 @@ private:
 	double lmparam_smoothing1;
 	double lmparam_smoothing2;
 	double lmparam_mixture;
-	double lmparam_delta;
-	bool lmparam_enable_dirplus;
 
 	// private access routines
 	void record_tag( string config_tag, string config_value );
@@ -149,8 +147,6 @@ public:
 	double get_lmparam_smoothing1() { return lmparam_smoothing1; }	
 	double get_lmparam_smoothing2() { return lmparam_smoothing2; }
 	double get_lmparam_mixture() { return lmparam_mixture; }
-	double get_lmparam_delta() { return lmparam_delta; }
-	bool get_lmparam_enable_dirplus() { return lmparam_enable_dirplus; }
 
 }; // END class CONFIG
 

--- a/src/config_file.h
+++ b/src/config_file.h
@@ -79,6 +79,8 @@ private:
 	double lmparam_smoothing1;
 	double lmparam_smoothing2;
 	double lmparam_mixture;
+	double lmparam_delta;
+	bool lmparam_enable_dirplus;
 
 	// private access routines
 	void record_tag( string config_tag, string config_value );
@@ -141,18 +143,14 @@ public:
 	double get_bm25plusparam_delta() { return bm25plusparam_delta; }
 
 	double get_tradparam_k() { return tradparam_k; }
-	
+
 	double get_lmparam_log() { return lmparam_log; }
-
 	Xapian::Weight::type_smoothing get_lmparam_select_smoothing() { return lmparam_select_smoothing; }
-
-	double get_lmparam_smoothing1() { return lmparam_smoothing1
-; }
-	
+	double get_lmparam_smoothing1() { return lmparam_smoothing1; }	
 	double get_lmparam_smoothing2() { return lmparam_smoothing2; }
-
 	double get_lmparam_mixture() { return lmparam_mixture; }
-
+	double get_lmparam_delta() { return lmparam_delta; }
+	bool get_lmparam_enable_dirplus() { return lmparam_enable_dirplus; }
 
 }; // END class CONFIG
 

--- a/src/trec_search.cc
+++ b/src/trec_search.cc
@@ -159,7 +159,7 @@ int main(int argc, char **argv)
 	else if (config.use_weightingscheme("lmweight")) {
 		cout<<"Config Check LM"<<config.check_lmweight()<<endl;
 		if (config.check_lmweight()) {
-			enquire.set_weighting_scheme(Xapian::LMWeight(config.get_lmparam_log(),config.get_lmparam_select_smoothing(),config.get_lmparam_smoothing1(),config.get_lmparam_smoothing2(),config.get_lmparam_delta(),config.get_lmparam_enable_dirplus()));
+			enquire.set_weighting_scheme(Xapian::LMWeight(config.get_lmparam_log(),config.get_lmparam_select_smoothing(),config.get_lmparam_smoothing1(),config.get_lmparam_smoothing2()));
 		}
 		else {
 			enquire.set_weighting_scheme(Xapian::LMWeight());

--- a/src/trec_search.cc
+++ b/src/trec_search.cc
@@ -168,6 +168,14 @@ int main(int argc, char **argv)
 	else if (config.use_weightingscheme("boolweight")) {
 		enquire.set_weighting_scheme(Xapian::BoolWeight());
 	}
+	else if (config.use_weightingscheme("bm25plus"))
+	{
+		if (config.check_bm25plus()) {
+			enquire.set_weighting_scheme(Xapian::BM25PlusWeight(config.get_bm25plusparam_k1(),config.get_bm25plusparam_k2(),config.get_bm25plusparam_k3(),config.get_bm25plusparam_b(),config.get_bm25plusparam_min_normlen(), config.get_bm25plusparam_delta()));
+		}
+		else {
+			enquire.set_weighting_scheme(Xapian::BM25PlusWeight());		   }
+	}
 	// Get the top n results of the query
 	Xapian::MSet matches = enquire.get_mset( 0, config.get_noresults() );
 								

--- a/src/trec_search.cc
+++ b/src/trec_search.cc
@@ -159,7 +159,7 @@ int main(int argc, char **argv)
 	else if (config.use_weightingscheme("lmweight")) {
 		cout<<"Config Check LM"<<config.check_lmweight()<<endl;
 		if (config.check_lmweight()) {
-			enquire.set_weighting_scheme(Xapian::LMWeight(config.get_lmparam_log(),config.get_lmparam_select_smoothing(),config.get_lmparam_smoothing1(),config.get_lmparam_smoothing2()));
+			enquire.set_weighting_scheme(Xapian::LMWeight(config.get_lmparam_log(),config.get_lmparam_select_smoothing(),config.get_lmparam_smoothing1(),config.get_lmparam_smoothing2(),config.get_lmparam_delta(),config.get_lmparam_enable_dirplus()));
 		}
 		else {
 			enquire.set_weighting_scheme(Xapian::LMWeight());
@@ -167,14 +167,6 @@ int main(int argc, char **argv)
 	}
 	else if (config.use_weightingscheme("boolweight")) {
 		enquire.set_weighting_scheme(Xapian::BoolWeight());
-	}
-	else if (config.use_weightingscheme("bm25plus"))
-	{
-		if (config.check_bm25plus()) {
-			enquire.set_weighting_scheme(Xapian::BM25PlusWeight(config.get_bm25plusparam_k1(),config.get_bm25plusparam_k2(),config.get_bm25plusparam_k3(),config.get_bm25plusparam_b(),config.get_bm25plusparam_min_normlen(), config.get_bm25plusparam_delta()));
-		}
-		else {
-			enquire.set_weighting_scheme(Xapian::BM25PlusWeight());		   }
 	}
 	// Get the top n results of the query
 	Xapian::MSet matches = enquire.get_mset( 0, config.get_noresults() );


### PR DESCRIPTION
This PR requires Dir+ weighting scheme support implemented in Xapian to build successfully. Please refer [here](https://github.com/xapian/xapian/pull/111) to obtain Dir+ implementation and move xapian-evaluation folder to xapian source root directory.
