### PR TITLE
Tf-Idf Weighting scheme evaluation

### DIFF
--- a/src/config_file.cc
+++ b/src/config_file.cc
@@ -280,7 +280,7 @@ void CONFIG_TREC::setup_config( string filename ) {
   lmparam_smoothing1 = -1.0;
   lmparam_smoothing2 = -1.0;
   lmparam_mixture = -1.0;
-  normalizations = "ntn";
+  normalizations = string();
   pivplusparam_slope = -1.0;
   pivplusparam_delta = -1.0;
 

--- a/src/config_file.cc
+++ b/src/config_file.cc
@@ -25,6 +25,7 @@
 #include <fstream>
 #include <algorithm>
 #include <string>
+#include <cstring>
 #include <xapian.h>
 #include "config_file.h"
 #include "split.h" 
@@ -219,6 +220,21 @@ void CONFIG_TREC::record_tag( string config_tag, string config_value ) {
   	found = 1;
   }
 
+  if (config_tag == "normalizations" ) {
+	normalizations = config_value;
+	found = 1;
+  }
+
+  if (config_tag == "pivplusparam_slope" ) {
+	pivplusparam_slope = strtod(config_value.c_str(),NULL);
+	found = 1;
+  }
+
+  if (config_tag == "pivplusparam_delta" ) {
+	pivplusparam_delta = strtod(config_value.c_str(),NULL);
+	found = 1;
+  }
+
   if( !found ) {
     cout << "ERROR: could not locate tag [" << config_tag << "] for value [" << config_value
 	 << "]" << endl;
@@ -264,6 +280,9 @@ void CONFIG_TREC::setup_config( string filename ) {
   lmparam_smoothing1 = -1.0;
   lmparam_smoothing2 = -1.0;
   lmparam_mixture = -1.0;
+  normalizations = "ntn";
+  pivplusparam_slope = -1.0;
+  pivplusparam_delta = -1.0;
 
   std::ifstream configfile( filename.c_str() );
   
@@ -432,6 +451,23 @@ bool CONFIG_TREC::check_bm25plus() {
 	if ( bm25plusparam_delta == -1.0 ) {
 		return false;
 	}	
+	return true;
+}
+
+bool CONFIG_TREC::check_tfidf() {
+//ensure that all the information or parameters requires by TfIdf are available.
+	if (normalizations.length() != 3 ||
+	!strchr("nbslP", normalizations[0]) ||
+	!strchr("ntpfsP", normalizations[1]) ||
+	!strchr("nP", normalizations[2])) {
+		return false;
+	}
+	if (pivplusparam_slope == -1.0) {
+		return false;
+	}
+	if (pivplusparam_delta == -1.0) {
+		return false;
+	}
 	return true;
 }
 

--- a/src/config_file.h
+++ b/src/config_file.h
@@ -80,6 +80,12 @@ private:
 	double lmparam_smoothing2;
 	double lmparam_mixture;
 
+	// Parameters for TfIdf Weighting Scheme
+
+	string normalizations;
+	double pivplusparam_slope;
+	double pivplusparam_delta;
+
 	// private access routines
 	void record_tag( string config_tag, string config_value );
 
@@ -99,6 +105,7 @@ public:
 	bool check_trad();
 	bool check_lmweight();
 	bool check_bm25plus();
+	bool check_tfidf();
 
 	// access routines
 	string get_textfile() { return textfile; }
@@ -146,13 +153,15 @@ public:
 
 	Xapian::Weight::type_smoothing get_lmparam_select_smoothing() { return lmparam_select_smoothing; }
 
-	double get_lmparam_smoothing1() { return lmparam_smoothing1
-; }
+	double get_lmparam_smoothing1() { return lmparam_smoothing1; }
 	
 	double get_lmparam_smoothing2() { return lmparam_smoothing2; }
 
 	double get_lmparam_mixture() { return lmparam_mixture; }
 
+	string get_normalizations() { return normalizations; }
+	double get_pivplusparam_slope() { return pivplusparam_slope; }
+	double get_pivplusparam_delta () { return pivplusparam_delta; }
 
 }; // END class CONFIG
 

--- a/src/trec_search.cc
+++ b/src/trec_search.cc
@@ -176,6 +176,14 @@ int main(int argc, char **argv)
 		else {
 			enquire.set_weighting_scheme(Xapian::BM25PlusWeight());		   }
 	}
+	else if (config.use_weightingscheme("tfidf"))
+	{
+		if (config.check_tfidf()) {
+			enquire.set_weighting_scheme(Xapian::TfIdfWeight(config.get_normalizations(), config.get_pivplusparam_slope(), config.get_pivplusparam_delta()));
+		} else {
+			enquire.set_weighting_scheme(Xapian::TfIdfWeight());
+		}
+	}
 	// Get the top n results of the query
 	Xapian::MSet matches = enquire.get_mset( 0, config.get_noresults() );
 								


### PR DESCRIPTION
This PR enables evaluation of existing Tf-Idf Weighting scheme in Xapian thus enabling evaluations of all normalizations including pivoted normalization for which support is provided in this [PR](https://github.com/xapian/xapian/pull/115).
