### PR TITLE
Make readme more User-friendly

### DIFF
--- a/README
+++ b/README
@@ -1,7 +1,17 @@
 Evaluation
 ==========
 
- Evaluation module is one of essential module for a search engine to be used in academia.This module ease to calculate various metric  precision, recall, precision @ rank,Precision @ recall which validates implementation and check the engine on result presented on literature.xapian being an open source engine have implemented evaluation module to help people from academia.
+Evaluation module is one of essential module for a search engine to be used in academia. This module eases to calculate various metric precision, recall, precision @ rank, Precision @ recall which validates implementation and check the engine on result presented on literature. Xapian being an open source engine have implemented evaluation module to help people from academia.
+
+Buiding Evaluation Module
+-------------------------
+
+User needs to build Evaluation module on their system after cloning the source repository. This can be done using
+::
+ autoreconfig -fiv
+ ./configure
+ make
+ sudo make install
 
 Using Evaluation Module
 ------------------------
@@ -15,35 +25,35 @@ Evaluation metric currently in xapian
  * Precision at Recall
  * Recall
 
-Indexing Collection with evaluation Module.
+Indexing Collection with evaluation Module
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 User can index a collection using
 ::
- . ./trec_index configuration_file
+ . ./trec_index <configuration_file>
 
 Find a sample config file in current directory names 'config'
 
-User need to compulsory configure textfile,db,stopfile parameters to be able to use index a collection.User need to set indexbigram parameter to true to be able to index bigrams while indexing to use bigram language model weighting scheme.
+User needs to compulsory configure textfile, db and stopsfile parameters to be able to use index a collection. User needs to set indexbigram parameter to true to be able to index bigrams while indexing to use bigram language model weighting scheme.
 
 Searching Topics file and creating run with evaluation module
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 User can search a collection using index build to create a run with queries in topic file.
 ::
- ./trec_query configuration_file;
- ./trec_search configuration_file
+ ./trec_query <configuration_file>
+ ./trec_search <configuration_file>
 
-User need to compulsory configure queryfile, topicfile, stopfile to search using a topic file,needs to set queryparserbigram to true to be able to add bigrams in query object formed by bigram.
+User need to compulsory configure queryfile, topicfile and stopsfile to search using a topic file, needs to set queryparserbigram to true to be able to add bigrams in query object formed by bigram.
 
-Evaluating the run.
+Evaluating the run
 ^^^^^^^^^^^^^^^^^^^
 
-User need to run to get the evaluation result for your run.
+User needs to run to get the evaluation result for your run.
 ::
  ./trec_adhoceval configuration_file
 
-It's compulsory to set relfile,runfile for using this option.
+It's compulsory to set relfile and runfile for using this option.
 
 Configuring evaluation module
 ------------------------------
@@ -51,30 +61,30 @@ Configuring evaluation module
 Configurable Parameters:
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-	 - textfile     - path/filename of text file to be indexed for evaluation
-	 - language     - corpus language to be indexed for stemming 
-	 - db           - path of database which is index of above textfile
-	 - querytype    - type of query
-	 - queryfile    - path/filename of query file to be ran and searched
-	 - resultsfile  - path/filename of results file(run file)
-	 - transfile    - path/filename of transaction file
-	 - noresults    - no of results to save in results log file
-	 - const_k1     - value for K1 constant (BM25)
-	 - const_b      - value for B constant (BM25)
-	 - topicfile    - path/filename of topic file for which relevance judgement file is available
-	 - topicfields  - fields of topic to use from topic file in evaluation
-	 - relfile      - path/filename of relevance judgements file
-	 - runname      - name of the evaluation run
-	 - nterms       - no of terms to pick from the topic
-	 - stopsfile    -  name of the stopword file
-	 - evaluationfiles - path/filename of the evaluation files(where evaluation result is stored).
-	 - indexbigram  - Index Bigram in the index.
-	 - queryparsebigram -  Parse and add bigrams to the Query.
-	 - weightingscheme - which weighting scheme to select(bm25,lmweight,trad,boolweight)
+	 - textfile     - (INPUT) path/filename of text file to be indexed for evaluation
+	 - language     - (INPUT) corpus language to be indexed for stemming
+	 - db           - (OUTPUT) path of database which is index of above textfile
+	 - querytype    - (INPUT) type of query
+	 - queryfile    - (OUTPUT) path/filename of query file to be ran and searched
+	 - resultsfile  - (OUTPUT) path/filename of results file(run file)
+	 - transfile    - (INPUT) path/filename of transaction file
+	 - noresults    - (INPUT) no of results to save in results log file
+	 - const_k1     - (INPUT) value for K1 constant (BM25)
+	 - const_b      - (INPUT) value for B constant (BM25)
+	 - topicfile    - (INPUT) path/filename of topic file for which relevance judgement file is available
+	 - topicfields  - (INPUT) fields of topic to use from topic file in evaluation
+	 - relfile      - (INPUT) path/filename of relevance judgements file
+	 - runname      - (INPUT) name of the evaluation run
+	 - nterms       - (INPUT) no of terms to pick from the topic
+	 - stopsfile    - (INPUT) name of the stopword file
+	 - evaluationfiles - (OUTPUT) path/filename of the evaluation files(where evaluation result is stored).
+	 - indexbigram  - (INPUT) Index Bigram in the index.
+	 - queryparsebigram -(INPUT) Parse and add bigrams to the Query.
+	 - weightingscheme - (INPUT) which weighting scheme to select(bm25, lmweight, tradweight, boolweight)
 
-Parameters to be configured using for BM25 Weighting Scheme
+Parameters to be configured for using BM25 Weighting Scheme
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-**All parameter need to be configured to call customized constructor.Please refer generated documentation for value of parameters. at https://xapian.org/docs/**
+**All parameters need to be configured to call customized constructor. Please refer generated documentation for value of parameters at https://xapian.org/docs/**
 
 	 - bm25param_k1
 	 - bm25param_k2
@@ -82,7 +92,7 @@ Parameters to be configured using for BM25 Weighting Scheme
 	 - bm25param_b
 	 - bm25param_min_normlen
 	
-Parameters for Trad Weighting scheme.
+Parameters for Trad Weighting Scheme
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 	 - tradparam_k
@@ -96,4 +106,4 @@ Parameters for LMWeight Weighting Scheme
 	 - lmparam_smoothing1
 	 - lmparam_smoothing2
 	 - lmparam_mixture
-     - lmparam_select_smoothing
+	 - lmparam_select_smoothing

--- a/README
+++ b/README
@@ -8,6 +8,7 @@ Buiding Evaluation Module
 
 User needs to build Evaluation module on their system after cloning the source repository. This can be done using
 ::
+
  autoreconf -fiv
  ./configure
  make
@@ -30,7 +31,8 @@ Indexing Collection with evaluation Module
 
 User can index a collection using
 ::
- . ./trec_index <configuration_file>
+
+ trec_index config
 
 Find a sample config file in current directory names 'config'
 
@@ -41,8 +43,9 @@ Searching Topics file and creating run with evaluation module
 
 User can search a collection using index build to create a run with queries in topic file.
 ::
- ./trec_query <configuration_file>
- ./trec_search <configuration_file>
+
+ trec_query config
+ trec_search config
 
 User need to compulsory configure queryfile, topicfile and stopsfile to search using a topic file, needs to set queryparserbigram to true to be able to add bigrams in query object formed by bigram.
 
@@ -51,7 +54,8 @@ Evaluating the run
 
 User needs to run to get the evaluation result for your run.
 ::
- ./trec_adhoceval configuration_file
+
+ trec_adhoceval config
 
 It's compulsory to set relfile and runfile for using this option.
 
@@ -80,7 +84,7 @@ Configurable Parameters:
 	 - evaluationfiles - (OUTPUT) path/filename of the evaluation files(where evaluation result is stored).
 	 - indexbigram  - (INPUT) Index Bigram in the index.
 	 - queryparsebigram -(INPUT) Parse and add bigrams to the Query.
-	 - weightingscheme - (INPUT) which weighting scheme to select(bm25, lmweight, tradweight, boolweight)
+	 - weightingscheme - (INPUT) which weighting scheme to select(bm25, lmweight, trad, boolweight)
 
 Parameters to be configured for using BM25 Weighting Scheme
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/README
+++ b/README
@@ -8,7 +8,7 @@ Buiding Evaluation Module
 
 User needs to build Evaluation module on their system after cloning the source repository. This can be done using
 ::
- autoreconfig -fiv
+ autoreconf -fiv
  ./configure
  make
  sudo make install


### PR DESCRIPTION
Add build instructions for user. Also avoid full stop in heading.
Clarify which parameters are for input and which are to store output.
Fix white space irregularities.