### PR TITLE
ci: Enable CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,77 @@
+dist: xenial
+language: cpp
+cache: ccache
+notifications:
+  irc: "chat.freenode.net#xapian-devel"
+matrix:
+  include:
+    - compiler: gcc
+      os: linux
+      addons:
+        apt:
+          packages:
+            - autoconf
+            - automake
+            - libtool
+            - doxygen
+            - graphviz
+            - help2man
+            - python-docutils
+            - pngcrush
+            - python-sphinx
+            - uuid-dev
+      env: CPPFLAGS=-D_GLIBCXX_DEBUG
+    - compiler: clang
+      os: linux
+      # Clang is already installed, but we want to build using the
+      # llvm c++ library, not the GCC one. (Otherwise, depending on
+      # the GCC version, there can be issues.)
+      addons:
+        apt:
+          packages:
+            - autoconf
+            - automake
+            - libtool
+            - doxygen
+            - graphviz
+            - help2man
+            - python-docutils
+            - pngcrush
+            - python-sphinx
+            - uuid-dev
+            - libc++-dev
+      env: USE_CC=clang USE_CXX='clang++ -stdlib=libc++'
+    - compiler: gcc
+      os: linux
+      name: "GCC 4.8"
+      # Test with trusty as it has GCC 4.8 which is the oldest GCC we currently
+      # aim to support.
+      dist: trusty
+      addons:
+        apt:
+          packages:
+            - autoconf
+            - automake
+            - libtool
+            - doxygen
+            - graphviz
+            - help2man
+            - python-docutils
+            - pngcrush
+            - python-sphinx
+            - uuid-dev
+
+
+before_script:
+  - travis_retry git clone https://github.com/xapian/xapian.git
+  - cd xapian
+  - travis_retry ./bootstrap xapian-core
+  - ./configure $confargs CC="$USE_CC" CXX="$USE_CXX"
+  - make -j2
+  - cd ..
+script:
+  - export ACLOCAL="aclocal -I $PWD/xapian/xapian-core/m4-macros"
+  - autoreconf -fiv
+  - ./configure XAPIAN_CONFIG=$PWD/xapian/xapian-core/xapian-config $confargs CC="$USE_CC" CXX="$USE_CXX"
+  - make -j2
+  - make check


### PR DESCRIPTION
Build against the current development version of xapian-core, since
we need features that aren't in releases yet.